### PR TITLE
add CSX to debuggable extensions

### DIFF
--- a/src/MonoDebugSession.cs
+++ b/src/MonoDebugSession.cs
@@ -19,7 +19,7 @@ namespace VSCodeDebug
 	{
 		private const string MONO = "mono";
 		private readonly string[] MONO_EXTENSIONS = new String[] {
-			".cs",
+			".cs", ".csx",
 			".fs", ".fsi", ".ml", ".mli", ".fsx", ".fsscript"
 		};
 		private const int MAX_CHILDREN = 100;


### PR DESCRIPTION
Roslyn is now able to [emit debugging symbols](https://github.com/dotnet/roslyn/pull/16489) for C# scripts too so it makes sense to add `.csx` to the list of allowed file extensions.