### PR TITLE
Add tests for FSharp debugging

### DIFF
--- a/.nuget/NuGet.Config
+++ b/.nuget/NuGet.Config
@@ -3,4 +3,7 @@
   <solution>
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
+  <packageSources>
+    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+  </packageSources>
 </configuration>

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ tests:
 	cd testdata/simple; make
 	cd testdata/output; make
 	cd testdata/simple_break; make
+	cd testdata/fsharp; make
 
 clean:
 	git clean -xfd

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ debug: $MONO_DEBUG_DEBUG
 	@echo "build finished"
 
 $MONO_DEBUG_RELEASE:
-	xbuild /p:Configuration=Release mono-debug.sln
+	msbuild /p:Configuration=Release mono-debug.sln
 
 $MONO_DEBUG_DEBUG:
-	xbuild /p:Configuration=Debug mono-debug.sln
+	msbuild /p:Configuration=Debug mono-debug.sln
 
 tests:
 	cd testdata/simple; make

--- a/src/typescript/tests/adapter.test.ts
+++ b/src/typescript/tests/adapter.test.ts
@@ -117,4 +117,14 @@ suite('Node Debug Adapter', () => {
 			]);
 		});
 	});
+
+	suite('FSharp Tests', () => {
+		const PROGRAM = Path.join(DATA_ROOT, 'fsharp/Program.exe');
+		const SOURCE = Path.join(DATA_ROOT, 'fsharp/Program.fs');
+		const BREAKPOINT_LINE = 6;
+
+		test('should stop on a breakpoint in an fsharp program', () => {
+			return dc.hitBreakpoint({ program: PROGRAM }, { path: SOURCE, line: BREAKPOINT_LINE } );
+		});
+	});
 });

--- a/testdata/fsharp/Makefile
+++ b/testdata/fsharp/Makefile
@@ -1,0 +1,2 @@
+Program.exe: Program.fs
+	fsharpc --debug:full Program.fs

--- a/testdata/fsharp/Program.fs
+++ b/testdata/fsharp/Program.fs
@@ -1,0 +1,8 @@
+open System
+open System.Diagnostics
+
+[<EntryPoint>]
+let main _ =
+    printfn "Hello World"
+    printfn "The End."
+    0


### PR DESCRIPTION
As it currently stands, this is the only debugger that actually works for FSharp development using VSCode on non-windows platforms. This PR adds a regression test to make sure that any further changes do not impact FSHarp debugging.