### PR TITLE
Support Xamarin

### DIFF
--- a/mono-debug.csproj
+++ b/mono-debug.csproj
@@ -66,6 +66,8 @@
     <Compile Include="src\DebugSession.cs" />
     <Compile Include="src\MonoDebug.cs" />
     <Compile Include="src\Protocol.cs" />
+    <Compile Include="src\XamarinConnectionProvider.cs" />
+    <Compile Include="src\XamarinDebuggerArgs.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/mono-debug.csproj
+++ b/mono-debug.csproj
@@ -68,6 +68,8 @@
     <Compile Include="src\Protocol.cs" />
     <Compile Include="src\XamarinConnectionProvider.cs" />
     <Compile Include="src\XamarinDebuggerArgs.cs" />
+    <Compile Include="src\XamarinTcpConnection.cs" />
+    <Compile Include="src\XamarinVirtualMachineManager.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/package.json
+++ b/package.json
@@ -144,11 +144,15 @@
 			],
 			"configurationAttributes": {
 				"launch": {
-					"required": ["program"],
+					"required": [],
 					"properties": {
 						"program": {
 							"type": "string",
 							"description": "%mono.launch.program.description%"
+						},
+						"packageName":{
+							"type": "string",
+							"description": "%mono.launch.packageName.description%"
 						},
 						"args": {
 							"type": "array",

--- a/package.nls.json
+++ b/package.nls.json
@@ -17,6 +17,7 @@
 	"mono.attach.config.name": "Attach",
 
 	"mono.launch.program.description": "Absolute path to the program.",
+	"mono.launch.packageName.description": "Android package name.",
 	"mono.launch.args.description": "Command line arguments passed to the program.",
 	"mono.launch.cwd.description": "Absolute path to the working directory of the program being debugged.",
 	"mono.launch.runtimeExecutable.description": "Absolute path to the runtime executable to be used. Default is the runtime executable on the PATH.",

--- a/src/DebugSession.cs
+++ b/src/DebugSession.cs
@@ -346,6 +346,10 @@ namespace VSCodeDebug
 					Attach(response, args);
 					break;
 
+				case "runXA":
+					RunXamarinAndroid(response, args);
+					break;
+
 				case "disconnect":
 					Disconnect(response, args);
 					break;
@@ -425,6 +429,8 @@ namespace VSCodeDebug
 		public abstract void Launch(Response response, dynamic arguments);
 
 		public abstract void Attach(Response response, dynamic arguments);
+
+		public abstract void RunXamarinAndroid(Response response, dynamic arguments); 
 
 		public abstract void Disconnect(Response response, dynamic arguments);
 

--- a/src/DebugSession.cs
+++ b/src/DebugSession.cs
@@ -346,10 +346,6 @@ namespace VSCodeDebug
 					Attach(response, args);
 					break;
 
-				case "runXA":
-					RunXamarinAndroid(response, args);
-					break;
-
 				case "disconnect":
 					Disconnect(response, args);
 					break;
@@ -429,8 +425,6 @@ namespace VSCodeDebug
 		public abstract void Launch(Response response, dynamic arguments);
 
 		public abstract void Attach(Response response, dynamic arguments);
-
-		public abstract void RunXamarinAndroid(Response response, dynamic arguments); 
 
 		public abstract void Disconnect(Response response, dynamic arguments);
 

--- a/src/MonoDebugSession.cs
+++ b/src/MonoDebugSession.cs
@@ -442,6 +442,7 @@ namespace VSCodeDebug
 			var forwardOutput = RunAdb("forward tcp:0 tcp:10000");
 			var port = int.Parse(forwardOutput);
 			RunAdb("shell setprop port=10000,timeout=2000000000");
+			RunAdb($"shell am force-stop {packageName}");
 			RunAdb($"shell monkey -p {packageName} -c android.intent.category.LAUNCHER 1");
 
 			lock (_lock) {

--- a/src/MonoDebugSession.cs
+++ b/src/MonoDebugSession.cs
@@ -444,6 +444,7 @@ namespace VSCodeDebug
 			RunAdb("shell setprop debug.mono.connect port=10000,timeout=2000000000");
 			RunAdb($"shell am force-stop {packageName}");
 			RunAdb($"shell monkey -p {packageName} -c android.intent.category.LAUNCHER 1");
+			System.Threading.Thread.Sleep(500);
 
 			lock (_lock) {
 

--- a/src/MonoDebugSession.cs
+++ b/src/MonoDebugSession.cs
@@ -441,7 +441,7 @@ namespace VSCodeDebug
 
 			var forwardOutput = RunAdb("forward tcp:0 tcp:10000");
 			var port = int.Parse(forwardOutput);
-			RunAdb("shell setprop port=10000,timeout=2000000000");
+			RunAdb("shell setprop debug.mono.connect port=10000,timeout=2000000000");
 			RunAdb($"shell am force-stop {packageName}");
 			RunAdb($"shell monkey -p {packageName} -c android.intent.category.LAUNCHER 1");
 

--- a/src/MonoDebugSession.cs
+++ b/src/MonoDebugSession.cs
@@ -415,6 +415,36 @@ namespace VSCodeDebug
 			SendResponse(response);
 		}
 
+		public override void RunXamarinAndroid(Response response, dynamic args)
+		{
+			_attachMode = true;
+
+			SetExceptionBreakpoints(args.__exceptionOptions);
+
+			// validate argument 'port'
+			var packageName = getInt(args, "packageName", -1);
+			if (packageName == -1) {
+				SendErrorResponse(response, 3008, "Property 'packageName' is missing.");
+				return;
+			}
+
+			lock (_lock) {
+
+				_debuggeeKilled = false;
+
+				var args0 = new XamarinDebuggerArgs(10000) {
+					MaxConnectionAttempts = MAX_CONNECTION_ATTEMPTS,
+					TimeBetweenConnectionAttempts = CONNECTION_ATTEMPT_INTERVAL
+				};
+
+				_session.Run(new Mono.Debugging.Soft.SoftDebuggerStartInfo(args0), _debuggerSessionOptions);
+
+				_debuggeeExecuting = true;
+			}
+
+			SendResponse(response);
+		}
+
 		public override void Disconnect(Response response, dynamic args)
 		{
 			if (_attachMode) {

--- a/src/XamarinConnectionProvider.cs
+++ b/src/XamarinConnectionProvider.cs
@@ -1,7 +1,11 @@
 using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
 using Mono.Debugger.Soft;
 using Mono.Debugging.Client;
 using Mono.Debugging.Soft;
+
 
 namespace VSCodeDebug
 {
@@ -16,22 +20,23 @@ namespace VSCodeDebug
 
         public IAsyncResult BeginConnect(DebuggerStartInfo dsi, AsyncCallback callback)
         {
-            throw new NotImplementedException();
+            return XamarinVirtualMachineManager.BeginConnect(new IPEndPoint(IPAddress.Parse("127.0.0.1"), _port), null, callback);
         }
 
         public void CancelConnect(IAsyncResult result)
         {
-            throw new NotImplementedException();
+            XamarinVirtualMachineManager.CancelConnection(result);
         }
 
         public void EndConnect(IAsyncResult result, out VirtualMachine vm, out string appName)
         {
-            throw new NotImplementedException();
+            vm = XamarinVirtualMachineManager.EndConnect(result);
+            appName = null;
         }
 
         public bool ShouldRetryConnection(Exception ex)
         {
-            throw new NotImplementedException();
+            return false;
         }
     }
 }

--- a/src/XamarinConnectionProvider.cs
+++ b/src/XamarinConnectionProvider.cs
@@ -1,0 +1,37 @@
+using System;
+using Mono.Debugger.Soft;
+using Mono.Debugging.Client;
+using Mono.Debugging.Soft;
+
+namespace VSCodeDebug
+{
+    public class XamarinConnectionProvider : ISoftDebuggerConnectionProvider
+    {
+        private readonly int _port;
+
+        public XamarinConnectionProvider(int port)
+        {
+            _port = port;
+        }
+
+        public IAsyncResult BeginConnect(DebuggerStartInfo dsi, AsyncCallback callback)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CancelConnect(IAsyncResult result)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void EndConnect(IAsyncResult result, out VirtualMachine vm, out string appName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool ShouldRetryConnection(Exception ex)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/XamarinDebuggerArgs.cs
+++ b/src/XamarinDebuggerArgs.cs
@@ -1,0 +1,14 @@
+using Mono.Debugging.Soft;
+
+namespace VSCodeDebug
+{
+    public class XamarinDebuggerArgs : SoftDebuggerStartArgs
+    {
+        public override ISoftDebuggerConnectionProvider ConnectionProvider { get; }
+
+        public XamarinDebuggerArgs(int port)
+        {
+            ConnectionProvider = new XamarinConnectionProvider(port);
+        }
+    }
+}

--- a/src/XamarinTcpConnection.cs
+++ b/src/XamarinTcpConnection.cs
@@ -1,0 +1,46 @@
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using Mono.Debugger.Soft;
+
+namespace VSCodeDebug
+{
+    class XamarinTcpConnection : Connection
+	{
+		Socket socket;
+
+		internal XamarinTcpConnection (Socket socket, TextWriter logWriter)
+			: base (logWriter)
+		{
+			this.socket = socket;
+			//socket.SetSocketOption (SocketOptionLevel.IP, SocketOptionName.NoDelay, 1);
+		}
+		
+		internal EndPoint EndPoint {
+			get {
+				return socket.RemoteEndPoint;
+			}
+		}
+		
+		protected override int TransportSend (byte[] buf, int buf_offset, int len)
+		{
+			return socket.Send (buf, buf_offset, len, SocketFlags.None);
+		}
+		
+		protected override int TransportReceive (byte[] buf, int buf_offset, int len)
+		{
+			return socket.Receive (buf, buf_offset, len, SocketFlags.None);
+		}
+		
+		protected override void TransportSetTimeouts (int send_timeout, int receive_timeout)
+		{
+			socket.SendTimeout = send_timeout;
+			socket.ReceiveTimeout = receive_timeout;
+		}
+		
+		protected override void TransportClose ()
+		{
+			socket.Close ();
+		}
+	}
+}

--- a/src/XamarinVirtualMachineManager.cs
+++ b/src/XamarinVirtualMachineManager.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.Remoting.Messaging;
+using System.Text;
+using Mono.Debugger.Soft;
+
+namespace VSCodeDebug
+{
+
+	public static class XamarinVirtualMachineManager
+	{
+		private delegate VirtualMachine LaunchCallback (ITargetProcess p, ProcessStartInfo info, Socket socket, TextWriter logWriter);
+		private delegate VirtualMachine ListenCallback (Socket dbg_sock, Socket con_sock, TextWriter logWriter); 
+		private delegate VirtualMachine ConnectCallback (Socket dbg_sock, Socket con_sock, IPEndPoint dbg_ep, IPEndPoint con_ep, TextWriter logWriter); 
+
+		public static VirtualMachine ConnectInternal (Socket dbg_sock, Socket con_sock, IPEndPoint dbg_ep, IPEndPoint con_ep, TextWriter logWriter = null) {
+			if (con_sock != null) {
+				try {
+					con_sock.Connect (con_ep);
+				} catch (Exception) {
+					try {
+						dbg_sock.Close ();
+					} catch { }
+					throw;
+				}
+			}
+
+			try {
+				dbg_sock.Connect (dbg_ep);
+                byte[] byData = new byte[] { 19 } ;
+                dbg_sock.Send(byData, 0, byData.Length, SocketFlags.None);
+                byData = System.Text.Encoding.ASCII.GetBytes("start debugger: sdb");
+			    dbg_sock.Send(byData, 0, byData.Length, SocketFlags.None);
+			} catch (Exception) {
+				if (con_sock != null) {
+					try {
+						con_sock.Close ();
+					} catch { }
+				}
+				throw;
+			}
+
+			Connection transport = new XamarinTcpConnection (dbg_sock, logWriter);			
+			StreamReader console = con_sock != null ? new StreamReader (new NetworkStream (con_sock)) : null;
+
+			return VirtualMachineManager.Connect (transport, console, null);
+		}
+
+		public static IAsyncResult BeginConnect (IPEndPoint dbg_ep, AsyncCallback callback, TextWriter logWriter = null) {
+			return BeginConnect (dbg_ep, null, callback, logWriter);
+		}
+
+		public static IAsyncResult BeginConnect (IPEndPoint dbg_ep, IPEndPoint con_ep, AsyncCallback callback, TextWriter logWriter = null) {
+			Socket dbg_sock = null;
+			Socket con_sock = null;
+
+			dbg_sock = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+			if (con_ep != null) {
+				con_sock = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+			}
+			
+			ConnectCallback c = new ConnectCallback (ConnectInternal);
+			return c.BeginInvoke (dbg_sock, con_sock, dbg_ep, con_ep, logWriter, callback, con_sock ?? dbg_sock);
+		}
+
+		public static VirtualMachine EndConnect (IAsyncResult asyncResult) {
+			if (asyncResult == null)
+				throw new ArgumentNullException ("asyncResult");
+
+			if (!asyncResult.IsCompleted)
+				asyncResult.AsyncWaitHandle.WaitOne ();
+
+			AsyncResult result = (AsyncResult) asyncResult;
+			ConnectCallback cb = (ConnectCallback) result.AsyncDelegate;
+			return cb.EndInvoke (asyncResult);
+		}
+
+		public static void CancelConnection (IAsyncResult asyncResult)
+		{
+			((Socket)asyncResult.AsyncState).Close ();
+		}
+	}
+}


### PR DESCRIPTION
This is some kind of proof of concept, which shows that it's possible to debug Xamarin application using VS Code. I'd like you to review the idea and probably help me with advice.

Now it supports only Xamarin.Android, but Xamarin.IOS is similar.
To start debugging build and deploy Xamarin.Android application via command line or ide, then define "packageName": "com.yourapp.name" in launch configuration, then run debugger. Debugger expects that you have adb in path. I tested debugger only on mac os.

Xamarin uses some "special" way to connect sdb, you can find more details here https://github.com/xamarin/xamarin-macios/blob/xamarin-mac-3.4.0.33/runtime/monotouch-debug.m#L1270 android has similar code, so I just send few packages before starting connection.

I'm going to continue implementing Xamarin.Anroid debug, then I will implement Xamarin.IOS debug.

Please, share you thoughts about this feature with me.