### PR TITLE
add .hx to MONO_EXTENSIONS

### DIFF
--- a/src/MonoDebugSession.cs
+++ b/src/MonoDebugSession.cs
@@ -18,7 +18,8 @@ namespace VSCodeDebug
 		private const string MONO = "mono";
 		private readonly string[] MONO_EXTENSIONS = new String[] {
 			".cs", ".csx",
-			".fs", ".fsi", ".ml", ".mli", ".fsx", ".fsscript"
+			".fs", ".fsi", ".ml", ".mli", ".fsx", ".fsscript",
+			".hx"
 		};
 		private const int MAX_CHILDREN = 100;
 		private const int MAX_CONNECTION_ATTEMPTS = 10;


### PR DESCRIPTION
Let's add .hx extension to supported extensions.
Haxe is language which can be compiled to c#, it overrides path and line number using line directive.

This Haxe code:
```haxe
 public static function main() 
 {
        var array = 1...10;
        for (i in array){
            trace('Hello world $i');
        }
        
 }
```
will be compiled to this c# code:
```c#
public static void main() {
		unchecked {
			#line 5 "/Users/vadzimv/Projects/haxe_cs_debug/sample/Test.hx"
			global::IntIterator array = new global::IntIterator(1, 10);
			{
				#line 6 "/Users/vadzimv/Projects/haxe_cs_debug/sample/Test.hx"
				global::IntIterator _g = array;
				#line 6 "/Users/vadzimv/Projects/haxe_cs_debug/sample/Test.hx"
				while (( _g.min < _g.max )) {
					#line 6 "/Users/vadzimv/Projects/haxe_cs_debug/sample/Test.hx"
					int i = _g.min++;
					global::haxe.Log.trace.__hx_invoke2_o(default(double), global::haxe.lang.Runtime.concat("Hello world ", global::haxe.lang.Runtime.toString(i)), default(double), new global::haxe.lang.DynamicObject(new int[]{302979532, 1547539107, 1648581351}, new object[]{"main", "Test", "Test.hx"}, new int[]{1981972957}, new double[]{((double) (7) )}));
				}
				
			}
			
		}
		#line default
	}
```
Because of line directive mono debugger works well with .hx files, so I believe mono debugger can be used to debug haxe code for c# target without any other changes.