### PR TITLE
Add .cake extension to supported debug file types

### DIFF
--- a/src/MonoDebugSession.cs
+++ b/src/MonoDebugSession.cs
@@ -18,6 +18,7 @@ namespace VSCodeDebug
 		private const string MONO = "mono";
 		private readonly string[] MONO_EXTENSIONS = new String[] {
 			".cs", ".csx",
+			".cake",
 			".fs", ".fsi", ".ml", ".mli", ".fsx", ".fsscript",
 			".hx"
 		};


### PR DESCRIPTION
Currently, trying to debug `Cake.exe` while executing `.cake` script files will not hit any breakpoints set inside of VS Code since the file type is not supported.

Adding the file extension `.cake` to this list of supported extensions allows us to launch `Cake.exe` with the mono soft debugger, and subsequently attach to it with this extension to debug our cake scripts.

Here's a screenshot of a cake script with breakpoints working after this change:
![image](https://user-images.githubusercontent.com/271950/28795855-5b345b7a-7609-11e7-9381-11fc8edd2122.png)

Finally, here's how we're launching and attaching via cake if anyone's interested in seeing it:

```
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "StartCake",
            "type": "mono",
            "request": "launch",
            "program": "${workspaceRoot}/tools/Cake/Cake.exe",
            "runtimeArgs": [
                "--debug",
                "--debugger-agent=transport=dt_socket,server=y,address=127.0.0.1:55556"
            ],
            "args": [
                "${workspaceRoot}/build.cake",
                "--verbosity=diagnostic",
                "--debug"
            ],
            "cwd": "${workspaceRoot}",
            "console":"internalConsole",
            "noDebug": true
        },
       {
            "name": "AttachCake",
            "type": "mono",
            "request": "attach",
            "address": "localhost",
            "port": 55556
        }
    ],
     "compounds": [
        {
            "name": "DebugCake",
            "configurations": ["StartCake", "AttachCake"]
        }
    ]
}
```