### PR TITLE
Let's fix build

### DIFF
--- a/src/typescript/tests/adapter.test.ts
+++ b/src/typescript/tests/adapter.test.ts
@@ -88,7 +88,7 @@ suite('Node Debug Adapter', () => {
 			return Promise.all([
 				dc.configurationSequence(),
 				dc.launch({ program: PROGRAM }),
-				dc.assertStoppedLocation('step', DEBUGGER_LINE)
+				dc.assertStoppedLocation('step', {line:DEBUGGER_LINE})
 			]);
 		});
 	});

--- a/src/typescript/tests/adapter.test.ts
+++ b/src/typescript/tests/adapter.test.ts
@@ -83,7 +83,7 @@ suite('Node Debug Adapter', () => {
 		test('should stop on debugger statement', () => {
 
 			const PROGRAM = Path.join(DATA_ROOT, 'simple_break/Program.exe');
-			const DEBUGGER_LINE = 10;
+			const DEBUGGER_LINE = 11;
 
 			return Promise.all([
 				dc.configurationSequence(),


### PR DESCRIPTION
fixed build error: src/typescript/tests/adapter.test.ts(91,38): error TS2559: Type '10' has no properties in common with type '{ path?: string | RegExp; line?: number; column?: number; }'.
Please, see more details here: https://travis-ci.org/Microsoft/vscode-mono-debug/builds/283593039