### PR TITLE
Add useRuntime option

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,6 +186,11 @@
 							],
 							"description": "%mono.launch.console.description%",
 							"default": "internalConsole"
+							},
+							"useRuntime": {
+								"type": "boolean",
+								"description": "%mono.launch.useRuntime.description%",
+								"default": true
 						}
 					}
 				},

--- a/package.nls.json
+++ b/package.nls.json
@@ -23,6 +23,7 @@
 	"mono.launch.runtimeArgs.description": "Optional arguments passed to the runtime executable.",
 	"mono.launch.env.description": "Environment variables passed to the program.",
 	"mono.launch.externalConsole.deprecationMessage": "Attribute 'externalConsole' is deprecated, use 'console' instead.",
+	"mono.launch.useRuntime.description": "Specify to use the .NET runtime to execute the application, or execute directly and set MONO_ENV_OPTIONS.",
 	"mono.launch.console.description": "Where to launch the debug target.",
 		"mono.launch.console.internalConsole.description": "VS Code Debug Console (which doesn't support to read input from a program)",
 		"mono.launch.console.integratedTerminal.description": "VS Code's integrated terminal",

--- a/src/typescript/tests/adapter.test.ts
+++ b/src/typescript/tests/adapter.test.ts
@@ -83,12 +83,12 @@ suite('Node Debug Adapter', () => {
 		test('should stop on debugger statement', () => {
 
 			const PROGRAM = Path.join(DATA_ROOT, 'simple_break/Program.exe');
-			const DEBUGGER_LINE = 10;
+			const DEBUGGER_LINE = 11;
 
 			return Promise.all([
 				dc.configurationSequence(),
 				dc.launch({ program: PROGRAM }),
-				dc.assertStoppedLocation('step', DEBUGGER_LINE)
+				dc.assertStoppedLocation('step', { line: DEBUGGER_LINE })
 			]);
 		});
 	});


### PR DESCRIPTION
This adds an option to specify that the runtime should be used to execute the program, or if it should set the MONO_ENV_OPTIONS instead and launch directly.

This is very useful for applications that have embedded mono in a native application.

Also includes a fix for the tests so it compiles correctly.

Fixes #52