### PR TITLE
Fix/Implement Pause On Exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.16.3
+* Added support for configuring handled and unhandled exceptions. Configure it on Breakpoints window.
+
 ## 0.16.2
 
 * Don't use MONO_ENV_OPTIONS to pass debug options by default, it causes issues when starting subprocesses: [Issue #68](https://github.com/microsoft/vscode-mono-debug/issues/68)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.16.3
-* Added support for configuring handled and unhandled exceptions. Configure it on Breakpoints window.
+* Added support for configuring handled and unhandled exceptions in the Breakpoints window.
 
 ## 0.16.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "mono-debug",
-	"version": "0.16.2",
+	"version": "0.16.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "mono-debug",
 	"displayName": "Mono Debug",
-	"version": "0.16.2",
+	"version": "0.16.3",
 	"publisher": "ms-vscode",
 	"description": "Visual Studio Code debugger extension for Mono",
 	"icon": "images/mono-debug-icon.png",

--- a/src/csharp/DebugSession.cs
+++ b/src/csharp/DebugSession.cs
@@ -176,6 +176,7 @@ namespace VSCodeDebug
 		public bool supportsFunctionBreakpoints;
 		public bool supportsConditionalBreakpoints;
 		public bool supportsEvaluateForHovers;
+		public bool supportsExceptionFilterOptions;
 		public dynamic[] exceptionBreakpointFilters;
 	}
 

--- a/src/csharp/MonoDebugSession.cs
+++ b/src/csharp/MonoDebugSession.cs
@@ -180,9 +180,9 @@ namespace VSCodeDebug
 
 				supportsExceptionFilterOptions = true,
 				exceptionBreakpointFilters = new dynamic[] {
-					new { filter = "always", label = "All Exceptions", @default=false, supportsCondition=true, description="Breaks on all throw errors, even if they're caught later.",
+					new { filter = "always", label = "All Exceptions", @default=false, supportsCondition=true, description="Break when an exception is thrown, even if it is caught later.",
 						  conditionDescription = "Comma-separated list of exception types to break on"},
-					new { filter = "uncaught", label = "Uncaught Exceptions", @default=false, supportsCondition=false, description="Breaks only on errors that are not handled."}
+					new { filter = "uncaught", label = "Uncaught Exceptions", @default=false, supportsCondition=false, description="Breaks only on exceptions that are not handled."}
 					}
 			});
 

--- a/src/csharp/MonoDebugSession.cs
+++ b/src/csharp/MonoDebugSession.cs
@@ -178,8 +178,8 @@ namespace VSCodeDebug
 				// This debug adapter does not support a side effect free evaluate request for data hovers.
 				supportsEvaluateForHovers = false,
 
-    			supportsExceptionFilterOptions = true,
-    			exceptionBreakpointFilters = new dynamic[] {
+				supportsExceptionFilterOptions = true,
+				exceptionBreakpointFilters = new dynamic[] {
 					new { filter = "always", label = "All Exceptions", @default=false, supportsCondition=true, description="Breaks on all throw errors, even if they're caught later.",
 						  conditionDescription = "Comma-separated list of exception types to break on"},
 					new { filter = "uncaught", label = "Uncaught Exceptions", @default=false, supportsCondition=false, description="Breaks only on errors that are not handled."}

--- a/src/typescript/extension.ts
+++ b/src/typescript/extension.ts
@@ -129,14 +129,14 @@ function configureExceptions() : void {
 	});
 }
 
-function setExceptionBreakpoints(model: ExceptionConfigurations) : Thenable<DebugProtocol.SetExceptionBreakpointsResponse | undefined> {
+function setExceptionBreakpoints(model: ExceptionConfigurations) : void {
 
 	const args: DebugProtocol.SetExceptionBreakpointsArguments = {
 		filters: [],
 		exceptionOptions: convertToExceptionOptions(model)
 	}
-
-	return vscode.commands.executeCommand<DebugProtocol.SetExceptionBreakpointsResponse>('workbench.customDebugRequest', 'setExceptionBreakpoints', args);
+	if (vscode.debug.activeDebugSession)
+		vscode.debug.activeDebugSession.customRequest('setExceptionBreakpoints', args);
 }
 
 function convertToExceptionOptions(model: ExceptionConfigurations) : DebugProtocol.ExceptionOptions[] {


### PR DESCRIPTION
With this implementation the user can set the exceptions behavior in this checkbox, similar to what they have when debugging on coreclr.
![image](https://user-images.githubusercontent.com/4503299/183214511-29093a3d-d01a-415d-bfeb-71f48d96c787.png)

Also it's possible to add set list of exceptions that you want to pause:
![image](https://user-images.githubusercontent.com/4503299/183214702-1ac0df6d-3ce4-44ea-a0e0-b8d44104c15c.png)

Also fixed in this PR: 'workbench.customDebugRequest' that doesn't exist anymore, as it's documented here:
https://code.visualstudio.com/updates/v1_18#_debug-api-updates

The old way of setting exceptions is still working, but it only works when the debugger is already running and you set the exception, this is another reason that we decide to support exceptions from DAP.
